### PR TITLE
feature: refactor tasks to use the "exports as tasks" method

### DIFF
--- a/build-tasks/BOILERPLATE.js
+++ b/build-tasks/BOILERPLATE.js
@@ -28,7 +28,7 @@ watch.description = ``
 /* TODO: watch flags */
 watch.flags = {}
 
-module.exports = {
+export {
   lint,
   compile,
   watch,

--- a/build-tasks/deploy.js
+++ b/build-tasks/deploy.js
@@ -1,7 +1,7 @@
 import gulp from 'gulp'
-import keys from '../gulp-keys'
 import gConfig from '../gulp-config'
 import pluginLoader from 'gulp-load-plugins'
+import { compile as compileAllSource } from './main'
 
 const src = gConfig.paths.sources
 const opts = gConfig.pluginOpts
@@ -9,9 +9,11 @@ const plugins = pluginLoader(opts.load)
 
 const deploySource = () => gulp.src(src.overwatch).pipe(plugins.deploy())
 
-const run = (cb) => gulp.series(keys.compile, deploySource)(cb)
-run.description = `Deploy production ready assets from ${gConfig.paths.base} to gh-pages branch on GitHub`
+// NOTE:: This is necessary in order to get more verbose metadata when running gulp -T
+const compile = (cb) => compileAllSource(cb)
+const deploy = gulp.series(compile, deploySource)
+deploy.description = `Compile and deploy production ready assets from ${gConfig.paths.base} to gh-pages branch on GitHub`
 
-module.exports = {
-  run
+export {
+  deploy
 }

--- a/build-tasks/main.js
+++ b/build-tasks/main.js
@@ -1,0 +1,34 @@
+import gulp from 'gulp'
+
+import {
+  compileScripts,
+  lintScripts,
+  watchScripts,
+} from './scripts'
+
+import {
+  compileStyles,
+  lintStyles,
+  watchStyles,
+} from './styles'
+
+import {
+  compileMarkup,
+  lintMarkup,
+  watchMarkup,
+} from './markup'
+
+const lint = gulp.parallel(lintMarkup, lintStyles, lintScripts)
+lint.description = 'lint all source'
+
+const compile = gulp.parallel(compileMarkup, compileStyles, compileScripts)
+compile.description = 'compile all source'
+
+const watch = gulp.parallel(watchMarkup, watchStyles, watchScripts)
+watch.description = 'watch for changes to all source'
+
+export {
+  compile,
+  lint,
+  watch,
+}

--- a/build-tasks/markup.js
+++ b/build-tasks/markup.js
@@ -1,6 +1,5 @@
 import gulp from 'gulp'
 import gConfig from '../gulp-config'
-import keys from '../gulp-keys'
 import { getEnv } from './utils'
 import pluginLoader from 'gulp-load-plugins'
 
@@ -10,10 +9,10 @@ const src = gConfig.paths.sources
 const dest = gConfig.paths.destinations
 const plugins = pluginLoader(opts.load)
 
-const lint = () => gulp.src(src.markup).pipe(plugins.pugLint())
-lint.description = `lint markup source(${src.markup}) using pug-lint`
+const lintMarkup = () => gulp.src(src.markup).pipe(plugins.pugLint())
+lintMarkup.description = `lint markup source(${src.markup}) using pug-lint`
 
-const compile = () => {
+const compileMarkup = () => {
   opts.pug = Object.assign({}, opts.pug, {
     pretty: !(env.deploy && opts.pug.pretty),
     data: Object.assign({}, opts.pug.data, {
@@ -29,17 +28,17 @@ const compile = () => {
     .pipe(plugins.pug(opts.pug))
     .pipe(gulp.dest(dest.html))
 }
-compile.description = `compile markup source(${src.markup}) using pug`
-compile.flags = {
+compileMarkup.description = `compile markup source(${src.markup}) using pug`
+compileMarkup.flags = {
   '--deploy':
     'Turns off pretty option in pug and removes whitespace from output',
 }
 
-const watch = () => gulp.watch(src.markup, gulp.series(keys.lint_markup, keys.compile_markup))
-watch.description = `watch for changes in markup source(${src.markup}) and lint then compile on change`
+const watchMarkup = () => gulp.watch(src.markup, gulp.series(lintMarkup, compileMarkup))
+watchMarkup.description = `watch for changes in markup source(${src.markup}) and lint then compile on change`
 
-module.exports = {
-  compile,
-  lint,
-  watch,
+export {
+  compileMarkup,
+  lintMarkup,
+  watchMarkup,
 }

--- a/build-tasks/scripts.js
+++ b/build-tasks/scripts.js
@@ -1,6 +1,5 @@
 import gulp from 'gulp'
 import gConfig from '../gulp-config'
-import keys from '../gulp-keys'
 import { getEnv } from './utils'
 import { rollup } from 'rollup'
 import babel from 'rollup-plugin-babel'
@@ -14,15 +13,15 @@ const src = gConfig.paths.sources
 const dest = gConfig.paths.destinations
 const plugins = pluginLoader(opts.load)
 
-const lint = () => {
+const lintScripts = () => {
   return gulp
     .src(src.scripts.all)
     .pipe(plugins.eslint())
     .pipe(plugins.eslint.format())
 }
-lint.description = `lint script source(${src.scripts.all}) using eslint`
+lintScripts.description = `lint script source(${src.scripts.all}) using eslint`
 
-const compile = async function() {
+const compileScripts = async function() {
 
   const plugins = [
     resolve(),
@@ -57,19 +56,19 @@ const compile = async function() {
     })
   }
 }
-compile.description = `compile script source(${src.scripts.all}) using babel before concatenating and safety wrapping output`
-compile.flags = {
+compileScripts.description = `compile script source(${src.scripts.all}) using babel before concatenating and safety wrapping output`
+compileScripts.flags = {
   '--mapped': 'create source maps for scripts',
   '--deploy': `minify scripts output for deployment from ${dest.js}`,
   '--dist': `output both un-minified and minified scripts along with sourcemaps to dist directory`,
 }
 
-const watch = () =>
-  gulp.watch(src.scripts.all, gulp.series(keys.lint_scripts, keys.compile_scripts))
-watch.description = `watch for script source(${src.scripts.all}) changes and lint then compile on change`
+const watchScripts = () =>
+  gulp.watch(src.scripts.all, gulp.series(lintScripts, compileScripts))
+watchScripts.description = `watch for script source(${src.scripts.all}) changes and lint then compile on change`
 
-module.exports = {
-  compile,
-  lint,
-  watch,
+export {
+  compileScripts,
+  lintScripts,
+  watchScripts,
 }

--- a/build-tasks/server.js
+++ b/build-tasks/server.js
@@ -1,10 +1,10 @@
 import gulp from 'gulp'
-import keys from '../gulp-keys'
 import browsersync from 'browser-sync'
 import vss from 'vinyl-source-stream'
 import vb from 'vinyl-buffer'
 import vf from 'vinyl-file'
 import gConfig from '../gulp-config'
+import { compile as compileAllSource } from './main'
 
 const opts = gConfig.pluginOpts
 const src = gConfig.paths.sources
@@ -26,10 +26,9 @@ const startServer = () => {
         .pipe(server.stream())
   })
 }
-const start = (cb) => gulp.series(keys.compile, startServer)(cb)
-start.description = `creates a Browsersync instance that serves content from ${opts
+const compile = (cb) => compileAllSource(cb)
+const serve = gulp.series(compile, startServer)
+serve.description = `creates a Browsersync instance that serves content from ${opts
   .browserSync.server.baseDir} providing live reload and style injection`
 
-module.exports = {
-  start,
-}
+export { serve }

--- a/build-tasks/stat.js
+++ b/build-tasks/stat.js
@@ -1,20 +1,15 @@
-import gulp from'gulp'
+import gulp from 'gulp'
 import gConfig from '../gulp-config'
 import pluginLoader from 'gulp-load-plugins'
 
 const opts = gConfig.pluginOpts
-const plugins= pluginLoader(opts.load)
+const plugins = pluginLoader(opts.load)
 
-const run = () => {
-  return gulp
-    .src(`${gConfig.paths.base}/**/*.*`)
-    .pipe(plugins.size(opts.gSize))
-}
-run.description = `show sizing statistics for output files in current output directory, default being ${gConfig.paths.base}`
-run.flags = {
-  '--dist': 'show dist file sizes in the dist directory'
+const stat = () => gulp.src(`${gConfig.paths.base}/**/*.*`).pipe(plugins.size(opts.gSize))
+
+stat.description = `show sizing statistics for output files in current output directory, default being ${gConfig.paths.base}`
+stat.flags = {
+  '--dist': 'show dist file sizes in the dist directory',
 }
 
-module.exports = {
-  run
-}
+export { stat }

--- a/build-tasks/styles.js
+++ b/build-tasks/styles.js
@@ -1,6 +1,5 @@
 import gulp from 'gulp'
 import gConfig from '../gulp-config'
-import keys from '../gulp-keys'
 import { getEnv } from './utils'
 import pluginLoader from 'gulp-load-plugins'
 
@@ -10,14 +9,14 @@ const src = gConfig.paths.sources
 const dest = gConfig.paths.destinations
 const plugins = pluginLoader(opts.load)
 
-const lint = () =>
+const lintStyles = () =>
   gulp
     .src(src.styles.all)
     .pipe(plugins.stylint(opts.stylint))
     .pipe(plugins.stylint.reporter())
-lint.description = `lint style source(${src.styles.all}) using stylint`
+lintStyles.description = `lint style source(${src.styles.all}) using stylint`
 
-const compile = () =>
+const compileStyles = () =>
   gulp
     .src(src.styles.root)
     .pipe(plugins.plumber())
@@ -40,18 +39,18 @@ const compile = () =>
         ? gulp.dest(dest.css)
         : plugins.gUtil.noop()
     )
-compile.description = `concatenate and compile style source(${src.styles.all}) using stylus before autoprefixing and minifying`
-compile.flags = {
+compileStyles.description = `concatenate and compile style source(${src.styles.all}) using stylus before autoprefixing and minifying`
+compileStyles.flags = {
   '--deploy': `only create minified output in the deployment directory ${dest.css}`,
   '--dist': `output both un-minified and minified styles to dist directory`,
 }
 
-const watch = () =>
-  gulp.watch(src.styles.all, gulp.series(keys.lint_styles, keys.compile_styles))
-watch.description = `watch for style source(${src.styles.all}) changes and lint then compile on change`
+const watchStyles = () =>
+  gulp.watch(src.styles.all, gulp.series(lintStyles, compileStyles))
+watchStyles.description = `watch for style source(${src.styles.all}) changes and lint then compile on change`
 
-export default {
-  compile,
-  lint,
-  watch,
+export {
+  compileStyles,
+  lintStyles,
+  watchStyles,
 }

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -1,46 +1,44 @@
 import gulp from 'gulp'
 import gutil from 'gulp-util'
-import keys from './gulp-keys'
-import server from './build-tasks/server'
-import scripts from './build-tasks/scripts'
-import styles from './build-tasks/styles'
-import markup from './build-tasks/markup'
-import deploy from './build-tasks/deploy'
-import stat from './build-tasks/stat'
 
-gulp.task(keys.lint_scripts, scripts.lint)
-gulp.task(keys.compile_scripts, scripts.compile)
-gulp.task(keys.watch_scripts, scripts.watch)
+import {
+  compileScripts,
+  lintScripts,
+  watchScripts,
+} from './build-tasks/scripts'
+import { compileStyles, lintStyles, watchStyles } from './build-tasks/styles'
+import { compileMarkup, lintMarkup, watchMarkup } from './build-tasks/markup'
 
-gulp.task(keys.lint_styles, styles.lint)
-gulp.task(keys.compile_styles, styles.compile)
-gulp.task(keys.watch_styles, styles.watch)
+import { compile, lint, watch as watchEverything } from './build-tasks/main'
+import { deploy } from './build-tasks/deploy'
+import { stat } from './build-tasks/stat'
+import { serve as serveEverything } from './build-tasks/server'
 
-gulp.task(keys.lint_markup, markup.lint)
-gulp.task(keys.compile_markup, markup.compile)
-gulp.task(keys.watch_markup, markup.watch)
+export {
+  deploy,
+  serveEverything as serve,
+  stat,
+  compile,
+  lint,
+  watchEverything as watch,
+  compileScripts,
+  compileMarkup,
+  compileStyles,
+  lintScripts,
+  lintStyles,
+  lintMarkup,
+  watchScripts,
+  watchStyles,
+  watchMarkup,
+}
 
-gulp.task(
-  keys.lint,
-  gulp.parallel(keys.lint_markup, keys.lint_styles, keys.lint_scripts)
-)
-
-gulp.task(
-  keys.compile,
-  gulp.parallel(keys.compile_markup, keys.compile_styles, keys.compile_scripts)
-)
-
-gulp.task(
-  keys.watch,
-  gulp.parallel(keys.watch_markup, keys.watch_styles, keys.watch_scripts)
-)
-
-gulp.task(keys.serve, server.start)
-gulp.task(keys.deploy, deploy.run)
-gulp.task(keys.stat, stat.run)
-
+const serve = (cb) => serveEverything(cb)
+const watch = (cb) => watchEverything(cb)
 const defaultTasks = gutil.env.deploy
-  ? gulp.series(keys.deploy)
-  : gulp.parallel(keys.serve, keys.watch)
+  ? gulp.series(deploy)
+  : gulp.parallel(
+      serve,
+      watch,
+    )
 
-gulp.task('default', defaultTasks)
+export default defaultTasks

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-boilerplate",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "a starting point for using gulp",
   "scripts": {
     "precommit": "yarn prettier-fix",


### PR DESCRIPTION
Addresses #19

* refactor tasks to use "exports as tasks"
* deprecate the use of "gulp.task" :sunglasses:
* in some places have to create wrapper functions to make metadata happy and verbose, can be seen in gulpfile.babel.js with watch and serve tasks